### PR TITLE
Create fetch all entries endpoint

### DIFF
--- a/api/core/all-entries.js
+++ b/api/core/all-entries.js
@@ -1,0 +1,28 @@
+/**
+* @author Eneh, James Erozonachi
+*
+* @description A module that fetches all entries in entry list
+*
+* */
+import formatResponse from './outputlib/response-format';
+
+export default function fetchAllEntries(diary) {
+  let returnResponse = {};
+  try {
+    const result = {
+      code: 200,
+      data: diary,
+    };
+    returnResponse = formatResponse(result);
+  } catch (error) {
+    const result = {
+      code: 500,
+      data: {
+        message: 'Unable to process request at the moment',
+      },
+    };
+    console.log(error.message);
+    returnResponse = formatResponse(result);
+  }
+  return returnResponse;
+}

--- a/api/core/outputlib/response-format.js
+++ b/api/core/outputlib/response-format.js
@@ -1,4 +1,9 @@
-
+/**
+* @author Eneh, James Erozonachi
+*
+* @description A module that formats API endpoints response before sending to client
+*
+* */
 export default function formatResponse(result) {
   if (result.code <= 201) {
     const response = {

--- a/api/routes/api-routes.js
+++ b/api/routes/api-routes.js
@@ -6,14 +6,18 @@
 *
 * */
 import newEntry from '../core/new-entry';
+import getAllEntries from '../core/all-entries';
 
 export default function apiRoutes(app, diary) {
   const urlPrefix = '/api/v1/';
+  app.get(`${urlPrefix}entries`, (req, res) => {
+    // GET /api/v1/entries
+    const result = getAllEntries(diary);
+    res.status(result.statusCode).send(result.data);
+  });
   app.post(`${urlPrefix}entries`, (req, res) => {
     // POST /api/v1/entries
     const result = newEntry(req.body, diary);
-
-    console.log(...diary);
     res.status(result.statusCode).send(result.data);
   });
 }

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 /**
 * @author Eneh, James Erozonachi
 *
-* @description entry-point of MyDiary Applicaction
+* @description entry-point (Server) of MyDiary Applicaction
 *
 * */
 import express from 'express';

--- a/spec-tests/entry-specs.js
+++ b/spec-tests/entry-specs.js
@@ -6,6 +6,7 @@
 * */
 import assert from 'assert';
 import newEntry from '../api/core/new-entry';
+import fetchAllEntries from '../api/core/all-entries';
 
 // test data for add entry module
 const testCase = [
@@ -66,6 +67,13 @@ const testCase = [
     },
   },
 ];
+const getAllExpectedResult = {
+  statusCode: 200,
+  data: JSON.stringify({
+    status: 'succeeded',
+    data: [{}],
+  }),
+};
 describe('Entry Specification', () => {
   // add entry module test
   describe('#newEntry()', () => {
@@ -73,6 +81,12 @@ describe('Entry Specification', () => {
       it(`should return ${entry.expectedResult}`, () => {
         assert.deepStrictEqual(newEntry(entry.testData, []), entry.expectedResult);
       });
+    });
+  });
+  // fetchAllEntries module test
+  describe('#fetchAllEntries()', () => {
+    it(`should return ${getAllExpectedResult}`, () => {
+      assert.deepStrictEqual(fetchAllEntries([{}]), getAllExpectedResult);
     });
   });
 });


### PR DESCRIPTION
API endpoint for fetching all entries in the entry list. It takes no
request payload, and should return response data in JSON format
containing string and array identifiers; status and data respectively,
to the requesting client, with status set to succeeded and data set to
array of all entries. It should also return to the client, a HTTP success
status code, 200.