### PR TITLE
Create fetch single entry endpoint

### DIFF
--- a/api/core/single-entry.js
+++ b/api/core/single-entry.js
@@ -1,0 +1,65 @@
+/**
+* @author Eneh, James Erozonachi
+*
+* @description A module that fetches a single entry from entry list
+*
+* */
+import formatResponse from './outputlib/response-format';
+
+export default function fetchSingleEntry(id, diary) {
+  let returnResponse = {};
+  const isIdInteger = Number.isInteger(parseInt(id, 10));
+  try {
+    if (id === null || id === undefined) {
+      const error = {
+        code: 400,
+        data: { message: 'Entry ID is required' },
+      };
+      throw error;
+    }
+    if (!isIdInteger) {
+      const error = {
+        code: 400,
+        data: { message: 'Invalid entry ID' },
+      };
+      throw error;
+    }
+    if (parseInt(id, 10) < 0) {
+      const error = {
+        code: 400,
+        data: { message: 'Entry ID cannot be a negative number' },
+      };
+      throw error;
+    }
+    const entry = diary[parseInt(id, 10)];
+    if (entry === null || entry === undefined) {
+      const result = {
+        code: 404,
+        data: {
+          message: 'ID out of range! No entry found for the specified Id',
+        },
+      };
+      returnResponse = formatResponse(result);
+    } else {
+      const result = {
+        code: 200,
+        data: entry,
+      };
+      returnResponse = formatResponse(result);
+    }
+  } catch (error) {
+    if (error.code === 400) {
+      returnResponse = formatResponse(error);
+    } else {
+      const result = {
+        code: 500,
+        data: {
+          message: 'Unable to process request at the moment',
+        },
+      };
+      console.log(error.message);
+      returnResponse = formatResponse(result);
+    }
+  }
+  return returnResponse;
+}

--- a/api/routes/api-routes.js
+++ b/api/routes/api-routes.js
@@ -7,15 +7,22 @@
 * */
 import newEntry from '../core/new-entry';
 import getAllEntries from '../core/all-entries';
+import getSingleEntry from '../core/single-entry';
 
 export default function apiRoutes(app, diary) {
-  const urlPrefix = '/api/v1/';
-  app.get(`${urlPrefix}entries`, (req, res) => {
-    // GET /api/v1/entries
+  const route = '/api/v1/entries';
+  // GET /api/v1/entries
+  app.get(`${route}`, (req, res) => {
     const result = getAllEntries(diary);
     res.status(result.statusCode).send(result.data);
   });
-  app.post(`${urlPrefix}entries`, (req, res) => {
+  // GET /api/v1/entries/:entryId
+  app.get(`${route}/:entryId`, (req, res) => {
+    const entryId = req.params.entryId;
+    const result = getSingleEntry(entryId, diary);
+    res.status(result.statusCode).send(result.data);
+  });
+  app.post(`${route}`, (req, res) => {
     // POST /api/v1/entries
     const result = newEntry(req.body, diary);
     res.status(result.statusCode).send(result.data);

--- a/spec-tests/entry-specs.js
+++ b/spec-tests/entry-specs.js
@@ -7,9 +7,10 @@
 import assert from 'assert';
 import newEntry from '../api/core/new-entry';
 import fetchAllEntries from '../api/core/all-entries';
+import fetchSingleEntry from '../api/core/single-entry';
 
-// test data for add entry module
-const testCase = [
+// test data and expected result for add entry module
+const testCase1 = [
   {
     testData: {
       title: '',
@@ -67,6 +68,95 @@ const testCase = [
     },
   },
 ];
+// test data and expected result for fetch single entry module
+const testCase2 = [
+  {
+    testData: null,
+    store: [{
+      title: 'some title',
+      description: 'some description',
+      conclusion: 'some conclusion',
+      createdAt: '2018/07/20 01:25:07',
+    }],
+    expectedResult: {
+      statusCode: 400,
+      data: JSON.stringify({
+        status: 'failed',
+        data: { message: 'Entry ID is required' },
+      }),
+    },
+  },
+  {
+    testData: 'rtrtykj',
+    store: [{
+      title: 'some title',
+      description: 'some description',
+      conclusion: 'some conclusion',
+      createdAt: '2018/07/20 01:25:07',
+    }],
+    expectedResult: {
+      statusCode: 400,
+      data: JSON.stringify({
+        status: 'failed',
+        data: { message: 'Invalid entry ID' },
+      }),
+    },
+  },
+  {
+    testData: -1,
+    store: [{
+      title: 'some title',
+      description: 'some description',
+      conclusion: 'some conclusion',
+      createdAt: '2018/07/20 01:25:07',
+    }],
+    expectedResult: {
+      statusCode: 400,
+      data: JSON.stringify({
+        status: 'failed',
+        data: { message: 'Entry ID cannot be a negative number' },
+      }),
+    },
+  },
+  {
+    testData: 1,
+    store: [{
+      title: 'some title',
+      description: 'some description',
+      conclusion: 'some conclusion',
+      createdAt: '2018/07/20 01:25:07',
+    }],
+    expectedResult: {
+      statusCode: 404,
+      data: JSON.stringify({
+        status: 'failed',
+        data: { message: 'ID out of range! No entry found for the specified Id' },
+      }),
+    },
+  },
+  {
+    testData: 0,
+    store: [{
+      title: 'some title',
+      description: 'some description',
+      conclusion: 'some conclusion',
+      createdAt: '2018/07/20 01:25:07',
+    }],
+    expectedResult: {
+      statusCode: 200,
+      data: JSON.stringify({
+        status: 'succeeded',
+        data: {
+          title: 'some title',
+          description: 'some description',
+          conclusion: 'some conclusion',
+          createdAt: '2018/07/20 01:25:07',
+        },
+      }),
+    },
+  },
+];
+// Expected result for fetch all entries module 
 const getAllExpectedResult = {
   statusCode: 200,
   data: JSON.stringify({
@@ -77,7 +167,7 @@ const getAllExpectedResult = {
 describe('Entry Specification', () => {
   // add entry module test
   describe('#newEntry()', () => {
-    testCase.forEach((entry) => {
+    testCase1.forEach((entry) => {
       it(`should return ${entry.expectedResult}`, () => {
         assert.deepStrictEqual(newEntry(entry.testData, []), entry.expectedResult);
       });
@@ -87,6 +177,14 @@ describe('Entry Specification', () => {
   describe('#fetchAllEntries()', () => {
     it(`should return ${getAllExpectedResult}`, () => {
       assert.deepStrictEqual(fetchAllEntries([{}]), getAllExpectedResult);
+    });
+  });
+  // fetchSingleEntry module test
+  describe('#fetchSingleEntry()', () => {
+    testCase2.forEach((entry) => {
+      it(`should return ${entry.expectedResult}`, () => {
+        assert.deepStrictEqual(fetchSingleEntry(entry.testData, entry.store), entry.expectedResult);
+      });
     });
   });
 });


### PR DESCRIPTION
API endpoint for fetching single entry from entry list using it's
position Id (index). The Id should be append to the end of request url
with a preceeding forward slash, (eg. /api/v1/entries/Id).

If Id is not a valid non-negative integer value, the endpoint returns a
JSON error object and a HTTP status code of 400, to the requesting client.

If Id is valid and an entry object found at that position in the entry
list, the endpoint returns a JSON object containing the entry and a HTTP
status code of 200, to the client. Else, the endpoint returns a "Not
found" message in JSON and a HTTP status code of 404, to the client.