### PR TITLE
Create modify entry endpoint

### DIFF
--- a/api/core/all-entries.js
+++ b/api/core/all-entries.js
@@ -21,7 +21,6 @@ export default function fetchAllEntries(diary) {
         message: 'Unable to process request at the moment',
       },
     };
-    console.log(error.message);
     returnResponse = formatResponse(result);
   }
   return returnResponse;

--- a/api/core/modify-entry.js
+++ b/api/core/modify-entry.js
@@ -1,0 +1,98 @@
+/**
+* @author Eneh, James Erozonachi
+*
+* @description A module that updates existing entry object
+*
+* */
+import formatResponse from './outputlib/response-format';
+
+export default function modifyEntry(id, entryInfo, diary) {
+  let returnValue = {};
+  const isIdInteger = Number.isInteger(parseInt(id, 10));
+  try {
+    if (id === null || id === undefined) {
+      const error = {
+        code: 400,
+        data: { message: 'Entry ID is required' },
+      };
+      throw error;
+    }
+    if (!isIdInteger) {
+      const error = {
+        code: 400,
+        data: { message: 'Invalid entry ID' },
+      };
+      throw error;
+    }
+    if (parseInt(id, 10) < 0) {
+      const error = {
+        code: 400,
+        data: { message: 'Entry ID cannot be a negative number' },
+      };
+      throw error;
+    }
+    if (entryInfo.title.trim() === '' || entryInfo.title === null || entryInfo.title === undefined) {
+      const error = {
+        code: 400,
+        data: { message: 'Entry title is required' },
+      };
+      throw error;
+    }
+    if (entryInfo.title.length > 50) {
+      const error = {
+        code: 400,
+        data: { message: 'Entry title exceeds max character length of 50' },
+      };
+      throw error;
+    }
+    if (entryInfo.description.trim() === '' || entryInfo.description === null || entryInfo.description === undefined) {
+      const error = {
+        code: 400,
+        data: { message: 'Entry description is required' },
+      };
+      throw error;
+    }
+    const entry = diary[parseInt(id, 10)];
+    if (entry === null || entry === undefined) {
+      const result = {
+        code: 404,
+        data: {
+          message: 'ID out of range! No entry found for the specified Id',
+        },
+      };
+      returnValue = formatResponse(result);
+    } else {
+      if (entry.title !== entryInfo.title) {
+        entry.title = entryInfo.title;
+      }
+      if (entry.description !== entryInfo.description) {
+        entry.description = entryInfo.description;
+      }
+      if (entry.conclusion !== entryInfo.conclusion) {
+        entry.conclusion = entryInfo.conclusion;
+      }
+      const updatedAt = new Date().toLocaleString();
+      entry.updatedAt = updatedAt;
+      const result = {
+        code: 200,
+        data: {
+          message: 'Entry modified successfully',
+        },
+      };
+      returnValue = formatResponse(result);
+    }
+  } catch (error) {
+    if (error.code === 400) {
+      returnValue = formatResponse(error);
+    } else {
+      const result = {
+        code: 500,
+        data: {
+          message: 'Unable to process request at the moment',
+        },
+      };
+      returnValue = formatResponse(result);
+    }
+  }
+  return returnValue;
+}

--- a/api/core/new-entry.js
+++ b/api/core/new-entry.js
@@ -55,7 +55,6 @@ export default function newEntry(entryInfo, diary) {
           message: 'Unable to process request at the moment',
         },
       };
-      console.log(error.message);
       returnValue = formatResponse(result);
     }
   }

--- a/api/core/single-entry.js
+++ b/api/core/single-entry.js
@@ -57,7 +57,6 @@ export default function fetchSingleEntry(id, diary) {
           message: 'Unable to process request at the moment',
         },
       };
-      console.log(error.message);
       returnResponse = formatResponse(result);
     }
   }

--- a/api/routes/api-routes.js
+++ b/api/routes/api-routes.js
@@ -8,6 +8,7 @@
 import newEntry from '../core/new-entry';
 import getAllEntries from '../core/all-entries';
 import getSingleEntry from '../core/single-entry';
+import modifyEntry from '../core/modify-entry';
 
 export default function apiRoutes(app, diary) {
   const route = '/api/v1/entries';
@@ -18,13 +19,19 @@ export default function apiRoutes(app, diary) {
   });
   // GET /api/v1/entries/:entryId
   app.get(`${route}/:entryId`, (req, res) => {
-    const entryId = req.params.entryId;
+    const { entryId } = req.params;
     const result = getSingleEntry(entryId, diary);
     res.status(result.statusCode).send(result.data);
   });
   app.post(`${route}`, (req, res) => {
     // POST /api/v1/entries
     const result = newEntry(req.body, diary);
+    res.status(result.statusCode).send(result.data);
+  });
+  // PUT /api/v1/entries/:entryId
+  app.put(`${route}/:entryId`, (req, res) => {
+    const { entryId } = req.params;
+    const result = modifyEntry(entryId, req.body, diary);
     res.status(result.statusCode).send(result.data);
   });
 }

--- a/spec-tests/entry-specs.js
+++ b/spec-tests/entry-specs.js
@@ -8,6 +8,7 @@ import assert from 'assert';
 import newEntry from '../api/core/new-entry';
 import fetchAllEntries from '../api/core/all-entries';
 import fetchSingleEntry from '../api/core/single-entry';
+import modifyEntry from '../api/core/modify-entry';
 
 // test data and expected result for add entry module
 const testCase1 = [
@@ -156,7 +157,178 @@ const testCase2 = [
     },
   },
 ];
-// Expected result for fetch all entries module 
+// test data and expected result for modify entry module
+const testCase3 = [
+  {
+    testData: {
+      id: null,
+      entry: {
+        title: 'Entry title',
+        description: 'Entry description',
+        conclusion: '',
+      },
+    },
+    store: [{
+      title: 'some title',
+      description: 'some description',
+      conclusion: 'some conclusion',
+      createdAt: '2018/07/20 01:25:07',
+    }],
+    expectedResult: {
+      statusCode: 400,
+      data: JSON.stringify({
+        status: 'failed',
+        data: { message: 'Entry ID is required' },
+      }),
+    },
+  },
+  {
+    testData: {
+      id: 'gdhsjs',
+      entry: {
+        title: 'Entry title',
+        description: 'Entry description',
+        conclusion: '',
+      },
+    },
+    store: [{
+      title: 'some title',
+      description: 'some description',
+      conclusion: 'some conclusion',
+      createdAt: '2018/07/20 01:25:07',
+    }],
+    expectedResult: {
+      statusCode: 400,
+      data: JSON.stringify({
+        status: 'failed',
+        data: { message: 'Invalid entry ID' },
+      }),
+    },
+  },
+  {
+    testData: {
+      id: -1,
+      entry: {
+        title: 'Entry title',
+        description: 'Entry description',
+        conclusion: '',
+      },
+    },
+    store: [{
+      title: 'some title',
+      description: 'some description',
+      conclusion: 'some conclusion',
+      createdAt: '2018/07/20 01:25:07',
+    }],
+    expectedResult: {
+      statusCode: 400,
+      data: JSON.stringify({
+        status: 'failed',
+        data: { message: 'Entry ID cannot be a negative number' },
+      }),
+    },
+  },
+  {
+    testData: {
+      id: 0,
+      entry: {
+        title: '',
+        description: 'Entry description',
+        conclusion: '',
+      },
+    },
+    expectedResult: {
+      statusCode: 400,
+      data: JSON.stringify({
+        status: 'failed',
+        data: { message: 'Entry title is required' },
+      }),
+    },
+  },
+  {
+    testData: {
+      id: 0,
+      entry: {
+        title: 'Entry title blahhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh',
+        description: 'Entry description',
+        conclusion: '',
+      },
+    },
+    expectedResult: {
+      statusCode: 400,
+      data: JSON.stringify({
+        status: 'failed',
+        data: { message: 'Entry title exceeds max character length of 50' },
+      }),
+    },
+  },
+  {
+    testData: {
+      id: 0,
+      entry: {
+        title: 'Entry title',
+        description: '',
+        conclusion: '',
+      },
+    },
+    expectedResult: {
+      statusCode: 400,
+      data: JSON.stringify({
+        status: 'failed',
+        data: { message: 'Entry description is required' },
+      }),
+    },
+  },
+  {
+    testData: {
+      id: 1,
+      entry: {
+        title: 'Entry title',
+        description: 'Entry description',
+        conclusion: '',
+      },
+    },
+    store: [{
+      title: 'some title',
+      description: 'some description',
+      conclusion: 'some conclusion',
+      createdAt: '2018/07/20 01:25:07',
+    }],
+    expectedResult: {
+      statusCode: 404,
+      data: JSON.stringify({
+        status: 'failed',
+        data: { message: 'ID out of range! No entry found for the specified Id' },
+      }),
+    },
+  },
+  {
+    testData: {
+      id: 0,
+      entry: {
+        title: 'Entry title',
+        description: 'Entry description',
+        conclusion: '',
+      },
+    },
+    store: [{
+      title: 'some title',
+      description: 'some description',
+      conclusion: 'some conclusion',
+      createdAt: '2018/07/20 01:25:07',
+    }],
+    expectedResult: {
+      statusCode: 200,
+      data: JSON.stringify({
+        status: 'succeeded',
+        data: {
+          message: 'Entry modified successfully',
+        },
+      }),
+    },
+  },
+];
+// Expected result for fetch all entries module
 const getAllExpectedResult = {
   statusCode: 200,
   data: JSON.stringify({
@@ -184,6 +356,15 @@ describe('Entry Specification', () => {
     testCase2.forEach((entry) => {
       it(`should return ${entry.expectedResult}`, () => {
         assert.deepStrictEqual(fetchSingleEntry(entry.testData, entry.store), entry.expectedResult);
+      });
+    });
+  });
+  // modifyEntry module test
+  describe('#modifyEntry()', () => {
+    testCase3.forEach((entry) => {
+      it(`should return ${entry.expectedResult}`, () => {
+        assert.deepStrictEqual(modifyEntry(entry.testData.id, entry.testData.entry, entry.store),
+          entry.expectedResult);
       });
     });
   });


### PR DESCRIPTION
API endpoint for modifying saved entry using it's position Id (index) in
the entry list. It takes a request payload in JSON format, which should
contain; title, description and conclusion of an entry to be modify. The
entry Id should be append to the end of request url with a preceeding
forward slash (eg. /api/v1/entries</id>). Request to this endpoint
will use HTTP verb, "PUT".

If Id is not a valid non-negative integer value, the endpoint returns
error object and a HTTP status code; 400, to the requesting client.

Title and description to overwrite the existing ones in the entry are
required. If they are not supplied, the endpoint responds to the request
with HTTP status code; 400 and a JSON response data containing error
object.

If Id and request payload are valid, and an entry object found at the
position of the Id in entry list, the endpoint returns JSON object of
success message and a HTTP status code; 200, to the client. Else, the
endpoint returns a "Not found" error message and a HTTP status code;
404, to the client.